### PR TITLE
仮のデザイン構造設計

### DIFF
--- a/app/Http/Controllers/Account/AccountController.php
+++ b/app/Http/Controllers/Account/AccountController.php
@@ -18,10 +18,15 @@ class AccountController extends Controller
         $account->birthday        = $request->date('birthday');
         $account->icon_image_path = $request->input('icon_image_path', '');
 
+        // 0 年齢非表示、1 年齢をあいまいに表示、2 年齢をはっきりと表示
+        $account->show_age_obscure = 2;
+
         if ($request->input('show_age_obscure')) {
-            $account->show_age_obscure = 0;
-        }else{
             $account->show_age_obscure = 1;
+        }
+
+        if ($request->input('not_show_age')) {
+            $account->show_age_obscure = 0;
         }
 
         $account->active_status = 1;

--- a/app/Http/Controllers/Account/AccountController.php
+++ b/app/Http/Controllers/Account/AccountController.php
@@ -16,7 +16,7 @@ class AccountController extends Controller
         $account->name = $request->input('name');
         $account->birthday = $request->date('birthday');
         $account->icon_image_path = $request->input('icon_image_path', '');
-        $account->show_age_obscure = $request->input('show_age_obscure', false);
+        $account->show_age_obscure = $request->input('show_age_obscure', 1);
         $account->active_status = 1;
 
         $account->save();

--- a/app/Http/Controllers/Account/AccountController.php
+++ b/app/Http/Controllers/Account/AccountController.php
@@ -12,11 +12,18 @@ class AccountController extends Controller
     public function create(CreateRequest $request)
     {
         $account = new Account;
-        $account->user_id = $request->user()->id;
-        $account->name = $request->input('name');
-        $account->birthday = $request->date('birthday');
+
+        $account->user_id         = $request->user()->id;
+        $account->name            = $request->input('name');
+        $account->birthday        = $request->date('birthday');
         $account->icon_image_path = $request->input('icon_image_path', '');
-        $account->show_age_obscure = $request->input('show_age_obscure', 1);
+
+        if ($request->input('show_age_obscure')) {
+            $account->show_age_obscure = 0;
+        }else{
+            $account->show_age_obscure = 1;
+        }
+
         $account->active_status = 1;
 
         $account->save();

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -34,13 +34,12 @@ class RegisteredUserController extends Controller
     public function store(Request $request)
     {
         $request->validate([
-            'name' => ['required', 'string', 'max:255'],
+            'name' => ['string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 
         $user = User::create([
-            'name' => $request->name,
             'email' => $request->email,
             'password' => Hash::make($request->password),
         ]);

--- a/app/Services/TweetService.php
+++ b/app/Services/TweetService.php
@@ -8,7 +8,7 @@ class TweetService
 {
   public function getTweets()
   {
-    return Tweet::orderBy('created_at', 'DESC')->get();
+    return Tweet::orderBy('created_at', 'DESC')->take(50)->get();
   }
 
   public function checkOwnTweet(int $userId, int $tweetId): bool

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -537,14 +537,14 @@ video {
   margin-left: 0.25rem;
 }.-mr-2 {
   margin-right: -0.5rem;
+}.mt-4 {
+  margin-top: 1rem;
 }.mt-1 {
   margin-top: 0.25rem;
 }.mt-2 {
   margin-top: 0.5rem;
 }.mb-4 {
   margin-bottom: 1rem;
-}.mt-4 {
-  margin-top: 1rem;
 }.ml-4 {
   margin-left: 1rem;
 }.ml-2 {
@@ -587,10 +587,10 @@ video {
   height: 1.5rem;
 }.h-12 {
   height: 3rem;
-}.h-20 {
-  height: 5rem;
 }.h-8 {
   height: 2rem;
+}.h-20 {
+  height: 5rem;
 }.min-h-screen {
   min-height: 100vh;
 }.w-5 {
@@ -607,12 +607,14 @@ video {
   width: 3rem;
 }.w-48 {
   width: 12rem;
-}.w-20 {
-  width: 5rem;
 }.w-8 {
   width: 2rem;
+}.w-1\/3 {
+  width: 33.333333%;
 }.w-1\/2 {
   width: 50%;
+}.w-20 {
+  width: 5rem;
 }.max-w-screen-sm {
   max-width: 640px;
 }.max-w-7xl {
@@ -747,9 +749,6 @@ video {
 }.bg-gray-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(243 244 246 / var(--tw-bg-opacity));
-}.bg-green-200 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(187 247 208 / var(--tw-bg-opacity));
 }.bg-blue-500 {
   --tw-bg-opacity: 1;
   background-color: rgb(59 130 246 / var(--tw-bg-opacity));
@@ -759,6 +758,9 @@ video {
 }.bg-gray-800 {
   --tw-bg-opacity: 1;
   background-color: rgb(31 41 55 / var(--tw-bg-opacity));
+}.bg-green-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(187 247 208 / var(--tw-bg-opacity));
 }.bg-pink-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(252 231 243 / var(--tw-bg-opacity));

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -516,6 +516,12 @@ video {
 }.mx-auto {
   margin-left: auto;
   margin-right: auto;
+}.mx-12 {
+  margin-left: 3rem;
+  margin-right: 3rem;
+}.my-12 {
+  margin-top: 3rem;
+  margin-bottom: 3rem;
 }.ml-3 {
   margin-left: 0.75rem;
 }.-ml-px {
@@ -684,6 +690,8 @@ video {
   border-bottom-right-radius: 0.375rem;
 }.border {
   border-width: 1px;
+}.border-2 {
+  border-width: 2px;
 }.border-b {
   border-bottom-width: 1px;
 }.border-t {
@@ -694,6 +702,8 @@ video {
   border-bottom-width: 2px;
 }.border-r {
   border-right-width: 1px;
+}.border-solid {
+  border-style: solid;
 }.border-gray-300 {
   --tw-border-opacity: 1;
   border-color: rgb(209 213 219 / var(--tw-border-opacity));
@@ -711,6 +721,9 @@ video {
 }.border-gray-400 {
   --tw-border-opacity: 1;
   border-color: rgb(156 163 175 / var(--tw-border-opacity));
+}.border-amber-600 {
+  --tw-border-opacity: 1;
+  border-color: rgb(217 119 6 / var(--tw-border-opacity));
 }.bg-white {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
@@ -732,18 +745,18 @@ video {
 }.bg-gray-800 {
   --tw-bg-opacity: 1;
   background-color: rgb(31 41 55 / var(--tw-bg-opacity));
-}.bg-emerald-200 {
+}.bg-green-200 {
   --tw-bg-opacity: 1;
-  background-color: rgb(167 243 208 / var(--tw-bg-opacity));
+  background-color: rgb(187 247 208 / var(--tw-bg-opacity));
 }.bg-pink-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(252 231 243 / var(--tw-bg-opacity));
 }.bg-lime-200 {
   --tw-bg-opacity: 1;
   background-color: rgb(217 249 157 / var(--tw-bg-opacity));
-}.bg-green-200 {
+}.bg-amber-600 {
   --tw-bg-opacity: 1;
-  background-color: rgb(187 247 208 / var(--tw-bg-opacity));
+  background-color: rgb(217 119 6 / var(--tw-bg-opacity));
 }.fill-current {
   fill: currentColor;
 }.p-4 {
@@ -752,6 +765,8 @@ video {
   padding: 0.5rem;
 }.p-6 {
   padding: 1.5rem;
+}.p-8 {
+  padding: 2rem;
 }.px-4 {
   padding-left: 1rem;
   padding-right: 1rem;
@@ -803,6 +818,8 @@ video {
   text-align: left;
 }.text-center {
   text-align: center;
+}.text-justify {
+  text-align: justify;
 }.font-sans {
   font-family: Nunito, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }.text-sm {
@@ -817,15 +834,15 @@ video {
 }.text-2xl {
   font-size: 1.5rem;
   line-height: 2rem;
-}.text-xs {
-  font-size: 0.75rem;
-  line-height: 1rem;
 }.text-lg {
   font-size: 1.125rem;
   line-height: 1.75rem;
-}.text-4xl {
-  font-size: 2.25rem;
-  line-height: 2.5rem;
+}.text-xs {
+  font-size: 0.75rem;
+  line-height: 1rem;
+}.text-6xl {
+  font-size: 3.75rem;
+  line-height: 1;
 }.font-medium {
   font-weight: 500;
 }.font-semibold {
@@ -885,18 +902,15 @@ video {
 }.text-gray-300 {
   --tw-text-opacity: 1;
   color: rgb(209 213 219 / var(--tw-text-opacity));
-}.text-green-400 {
+}.text-green-500 {
   --tw-text-opacity: 1;
-  color: rgb(74 222 128 / var(--tw-text-opacity));
+  color: rgb(34 197 94 / var(--tw-text-opacity));
 }.text-blue-500 {
   --tw-text-opacity: 1;
   color: rgb(59 130 246 / var(--tw-text-opacity));
 }.text-pink-300 {
   --tw-text-opacity: 1;
   color: rgb(249 168 212 / var(--tw-text-opacity));
-}.text-green-500 {
-  --tw-text-opacity: 1;
-  color: rgb(34 197 94 / var(--tw-text-opacity));
 }.underline {
   -webkit-text-decoration-line: underline;
           text-decoration-line: underline;

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -520,9 +520,6 @@ video {
 }.mx-auto {
   margin-left: auto;
   margin-right: auto;
-}.mx-12 {
-  margin-left: 3rem;
-  margin-right: 3rem;
 }.my-12 {
   margin-top: 3rem;
   margin-bottom: 3rem;
@@ -536,14 +533,12 @@ video {
   margin-bottom: 1.25rem;
 }.mt-3 {
   margin-top: 0.75rem;
-}.mt-2 {
-  margin-top: 0.5rem;
-}.mt-1 {
-  margin-top: 0.25rem;
 }.ml-1 {
   margin-left: 0.25rem;
 }.-mr-2 {
   margin-right: -0.5rem;
+}.mt-1 {
+  margin-top: 0.25rem;
 }.mt-2 {
   margin-top: 0.5rem;
 }.mb-4 {
@@ -582,16 +577,16 @@ video {
   display: none;
 }.h-5 {
   height: 1.25rem;
-}.h-12 {
-  height: 3rem;
-}.h-4 {
-  height: 1rem;
 }.h-16 {
   height: 4rem;
 }.h-10 {
   height: 2.5rem;
+}.h-4 {
+  height: 1rem;
 }.h-6 {
   height: 1.5rem;
+}.h-12 {
+  height: 3rem;
 }.h-20 {
   height: 5rem;
 }.h-8 {
@@ -602,18 +597,18 @@ video {
   width: 1.25rem;
 }.w-full {
   width: 100%;
-}.w-12 {
-  width: 3rem;
-}.w-4 {
-  width: 1rem;
 }.w-auto {
   width: auto;
+}.w-4 {
+  width: 1rem;
 }.w-6 {
   width: 1.5rem;
-}.w-20 {
-  width: 5rem;
+}.w-12 {
+  width: 3rem;
 }.w-48 {
   width: 12rem;
+}.w-20 {
+  width: 5rem;
 }.w-8 {
   width: 2rem;
 }.w-1\/2 {
@@ -720,17 +715,14 @@ video {
 }.border-gray-200 {
   --tw-border-opacity: 1;
   border-color: rgb(229 231 235 / var(--tw-border-opacity));
-}.border-green-700 {
-  --tw-border-opacity: 1;
-  border-color: rgb(21 128 61 / var(--tw-border-opacity));
-}.border-transparent {
-  border-color: transparent;
 }.border-gray-100 {
   --tw-border-opacity: 1;
   border-color: rgb(243 244 246 / var(--tw-border-opacity));
 }.border-gray-900 {
   --tw-border-opacity: 1;
   border-color: rgb(17 24 39 / var(--tw-border-opacity));
+}.border-transparent {
+  border-color: transparent;
 }.border-indigo-400 {
   --tw-border-opacity: 1;
   border-color: rgb(129 140 248 / var(--tw-border-opacity));
@@ -746,9 +738,6 @@ video {
 }.bg-gray-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(249 250 251 / var(--tw-bg-opacity));
-}.bg-green-100 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(220 252 231 / var(--tw-bg-opacity));
 }.bg-indigo-600 {
   --tw-bg-opacity: 1;
   background-color: rgb(79 70 229 / var(--tw-bg-opacity));
@@ -758,6 +747,9 @@ video {
 }.bg-gray-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(243 244 246 / var(--tw-bg-opacity));
+}.bg-green-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(187 247 208 / var(--tw-bg-opacity));
 }.bg-blue-500 {
   --tw-bg-opacity: 1;
   background-color: rgb(59 130 246 / var(--tw-bg-opacity));
@@ -767,9 +759,6 @@ video {
 }.bg-gray-800 {
   --tw-bg-opacity: 1;
   background-color: rgb(31 41 55 / var(--tw-bg-opacity));
-}.bg-green-200 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(187 247 208 / var(--tw-bg-opacity));
 }.bg-pink-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(252 231 243 / var(--tw-bg-opacity));
@@ -798,12 +787,12 @@ video {
 }.px-2 {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
-}.py-3 {
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
 }.py-12 {
   padding-top: 3rem;
   padding-bottom: 3rem;
+}.py-3 {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
 }.py-6 {
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
@@ -819,10 +808,6 @@ video {
 }.py-4 {
   padding-top: 1rem;
   padding-bottom: 1rem;
-}.pt-1 {
-  padding-top: 0.25rem;
-}.pb-4 {
-  padding-bottom: 1rem;
 }.pt-2 {
   padding-top: 0.5rem;
 }.pb-3 {
@@ -831,6 +816,8 @@ video {
   padding-top: 1rem;
 }.pb-1 {
   padding-bottom: 0.25rem;
+}.pt-1 {
+  padding-top: 0.25rem;
 }.pb-0 {
   padding-bottom: 0px;
 }.pl-3 {
@@ -847,18 +834,15 @@ video {
   text-align: left;
 }.text-center {
   text-align: center;
-}.text-justify {
-  text-align: justify;
 }.text-right {
   text-align: right;
+}.text-justify {
+  text-align: justify;
 }.font-sans {
   font-family: Nunito, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }.text-sm {
   font-size: 0.875rem;
   line-height: 1.25rem;
-}.text-2xl {
-  font-size: 1.5rem;
-  line-height: 2rem;
 }.text-base {
   font-size: 1rem;
   line-height: 1.5rem;
@@ -868,9 +852,6 @@ video {
 }.text-2xl {
   font-size: 1.5rem;
   line-height: 2rem;
-}.text-xs {
-  font-size: 0.75rem;
-  line-height: 1rem;
 }.text-lg {
   font-size: 1.125rem;
   line-height: 1.75rem;
@@ -914,12 +895,6 @@ video {
 }.text-green-600 {
   --tw-text-opacity: 1;
   color: rgb(22 163 74 / var(--tw-text-opacity));
-}.text-indigo-600 {
-  --tw-text-opacity: 1;
-  color: rgb(79 70 229 / var(--tw-text-opacity));
-}.text-white {
-  --tw-text-opacity: 1;
-  color: rgb(255 255 255 / var(--tw-text-opacity));
 }.text-gray-600 {
   --tw-text-opacity: 1;
   color: rgb(75 85 99 / var(--tw-text-opacity));
@@ -929,6 +904,12 @@ video {
 }.text-gray-800 {
   --tw-text-opacity: 1;
   color: rgb(31 41 55 / var(--tw-text-opacity));
+}.text-indigo-600 {
+  --tw-text-opacity: 1;
+  color: rgb(79 70 229 / var(--tw-text-opacity));
+}.text-white {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
 }.text-indigo-700 {
   --tw-text-opacity: 1;
   color: rgb(67 56 202 / var(--tw-text-opacity));
@@ -1011,12 +992,12 @@ video {
 }.hover\:border-gray-300:hover {
   --tw-border-opacity: 1;
   border-color: rgb(209 213 219 / var(--tw-border-opacity));
-}.hover\:bg-indigo-700:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(67 56 202 / var(--tw-bg-opacity));
 }.hover\:bg-gray-100:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(243 244 246 / var(--tw-bg-opacity));
+}.hover\:bg-indigo-700:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(67 56 202 / var(--tw-bg-opacity));
 }.hover\:bg-gray-50:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(249 250 251 / var(--tw-bg-opacity));
@@ -1035,26 +1016,26 @@ video {
 }.hover\:text-gray-400:hover {
   --tw-text-opacity: 1;
   color: rgb(156 163 175 / var(--tw-text-opacity));
-}.hover\:text-gray-800:hover {
-  --tw-text-opacity: 1;
-  color: rgb(31 41 55 / var(--tw-text-opacity));
 }.hover\:text-gray-700:hover {
   --tw-text-opacity: 1;
   color: rgb(55 65 81 / var(--tw-text-opacity));
 }.hover\:text-gray-900:hover {
   --tw-text-opacity: 1;
   color: rgb(17 24 39 / var(--tw-text-opacity));
+}.hover\:text-gray-800:hover {
+  --tw-text-opacity: 1;
+  color: rgb(31 41 55 / var(--tw-text-opacity));
 }.focus\:z-10:focus {
   z-index: 10;
 }.focus\:border-blue-300:focus {
   --tw-border-opacity: 1;
   border-color: rgb(147 197 253 / var(--tw-border-opacity));
-}.focus\:border-indigo-500:focus {
-  --tw-border-opacity: 1;
-  border-color: rgb(99 102 241 / var(--tw-border-opacity));
 }.focus\:border-gray-300:focus {
   --tw-border-opacity: 1;
   border-color: rgb(209 213 219 / var(--tw-border-opacity));
+}.focus\:border-indigo-500:focus {
+  --tw-border-opacity: 1;
+  border-color: rgb(99 102 241 / var(--tw-border-opacity));
 }.focus\:border-indigo-700:focus {
   --tw-border-opacity: 1;
   border-color: rgb(67 56 202 / var(--tw-border-opacity));

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -520,12 +520,18 @@ video {
   margin-left: 0.75rem;
 }.-ml-px {
   margin-left: -1px;
+}.mt-5 {
+  margin-top: 1.25rem;
+}.mb-5 {
+  margin-bottom: 1.25rem;
 }.mt-3 {
   margin-top: 0.75rem;
 }.ml-1 {
   margin-left: 0.25rem;
 }.-mr-2 {
   margin-right: -0.5rem;
+}.mt-2 {
+  margin-top: 0.5rem;
 }.mb-4 {
   margin-bottom: 1rem;
 }.mt-1 {
@@ -534,14 +540,8 @@ video {
   margin-top: 1rem;
 }.ml-4 {
   margin-left: 1rem;
-}.mt-2 {
-  margin-top: 0.5rem;
 }.ml-2 {
   margin-left: 0.5rem;
-}.mt-5 {
-  margin-top: 1.25rem;
-}.mb-5 {
-  margin-bottom: 1.25rem;
 }.mb-2 {
   margin-bottom: 0.5rem;
 }.mt-6 {
@@ -586,14 +586,14 @@ video {
   min-height: 100vh;
 }.w-5 {
   width: 1.25rem;
+}.w-full {
+  width: 100%;
 }.w-auto {
   width: auto;
 }.w-4 {
   width: 1rem;
 }.w-6 {
   width: 1.5rem;
-}.w-full {
-  width: 100%;
 }.w-20 {
   width: 5rem;
 }.w-48 {
@@ -602,10 +602,10 @@ video {
   width: 2rem;
 }.w-1\/2 {
   width: 50%;
-}.max-w-7xl {
-  max-width: 80rem;
 }.max-w-screen-sm {
   max-width: 640px;
+}.max-w-7xl {
+  max-width: 80rem;
 }.max-w-6xl {
   max-width: 72rem;
 }.max-w-xl {
@@ -697,12 +697,12 @@ video {
 }.border-gray-300 {
   --tw-border-opacity: 1;
   border-color: rgb(209 213 219 / var(--tw-border-opacity));
-}.border-gray-100 {
-  --tw-border-opacity: 1;
-  border-color: rgb(243 244 246 / var(--tw-border-opacity));
 }.border-gray-200 {
   --tw-border-opacity: 1;
   border-color: rgb(229 231 235 / var(--tw-border-opacity));
+}.border-gray-100 {
+  --tw-border-opacity: 1;
+  border-color: rgb(243 244 246 / var(--tw-border-opacity));
 }.border-indigo-400 {
   --tw-border-opacity: 1;
   border-color: rgb(129 140 248 / var(--tw-border-opacity));
@@ -732,14 +732,26 @@ video {
 }.bg-gray-800 {
   --tw-bg-opacity: 1;
   background-color: rgb(31 41 55 / var(--tw-bg-opacity));
+}.bg-emerald-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(167 243 208 / var(--tw-bg-opacity));
+}.bg-pink-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(252 231 243 / var(--tw-bg-opacity));
+}.bg-lime-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(217 249 157 / var(--tw-bg-opacity));
+}.bg-green-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(187 247 208 / var(--tw-bg-opacity));
 }.fill-current {
   fill: currentColor;
+}.p-4 {
+  padding: 1rem;
 }.p-2 {
   padding: 0.5rem;
 }.p-6 {
   padding: 1.5rem;
-}.p-4 {
-  padding: 1rem;
 }.px-4 {
   padding-left: 1rem;
   padding-right: 1rem;
@@ -873,9 +885,18 @@ video {
 }.text-gray-300 {
   --tw-text-opacity: 1;
   color: rgb(209 213 219 / var(--tw-text-opacity));
+}.text-green-400 {
+  --tw-text-opacity: 1;
+  color: rgb(74 222 128 / var(--tw-text-opacity));
 }.text-blue-500 {
   --tw-text-opacity: 1;
   color: rgb(59 130 246 / var(--tw-text-opacity));
+}.text-pink-300 {
+  --tw-text-opacity: 1;
+  color: rgb(249 168 212 / var(--tw-text-opacity));
+}.text-green-500 {
+  --tw-text-opacity: 1;
+  color: rgb(34 197 94 / var(--tw-text-opacity));
 }.underline {
   -webkit-text-decoration-line: underline;
           text-decoration-line: underline;
@@ -890,13 +911,13 @@ video {
   --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-}.shadow {
-  --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }.shadow-lg {
   --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}.shadow {
+  --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }.shadow-md {
   --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -537,14 +537,18 @@ video {
   margin-left: 0.25rem;
 }.-mr-2 {
   margin-right: -0.5rem;
-}.mt-4 {
-  margin-top: 1rem;
+}.mt-16 {
+  margin-top: 4rem;
+}.mb-8 {
+  margin-bottom: 2rem;
 }.mt-1 {
   margin-top: 0.25rem;
 }.mt-2 {
   margin-top: 0.5rem;
 }.mb-4 {
   margin-bottom: 1rem;
+}.mt-4 {
+  margin-top: 1rem;
 }.ml-4 {
   margin-left: 1rem;
 }.ml-2 {
@@ -561,8 +565,8 @@ video {
   margin-left: 3rem;
 }.-mt-px {
   margin-top: -1px;
-}.mb-8 {
-  margin-bottom: 2rem;
+}.mb-12 {
+  margin-bottom: 3rem;
 }.block {
   display: block;
 }.inline-block {
@@ -603,14 +607,14 @@ video {
   width: 1rem;
 }.w-6 {
   width: 1.5rem;
+}.w-1\/3 {
+  width: 33.333333%;
 }.w-12 {
   width: 3rem;
 }.w-48 {
   width: 12rem;
 }.w-8 {
   width: 2rem;
-}.w-1\/3 {
-  width: 33.333333%;
 }.w-1\/2 {
   width: 50%;
 }.w-20 {
@@ -697,8 +701,6 @@ video {
   border-bottom-right-radius: 0.375rem;
 }.border {
   border-width: 1px;
-}.border-2 {
-  border-width: 2px;
 }.border-b {
   border-bottom-width: 1px;
 }.border-t {
@@ -709,8 +711,6 @@ video {
   border-bottom-width: 2px;
 }.border-r {
   border-right-width: 1px;
-}.border-solid {
-  border-style: solid;
 }.border-gray-300 {
   --tw-border-opacity: 1;
   border-color: rgb(209 213 219 / var(--tw-border-opacity));
@@ -731,9 +731,6 @@ video {
 }.border-gray-400 {
   --tw-border-opacity: 1;
   border-color: rgb(156 163 175 / var(--tw-border-opacity));
-}.border-amber-600 {
-  --tw-border-opacity: 1;
-  border-color: rgb(217 119 6 / var(--tw-border-opacity));
 }.bg-white {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
@@ -767,9 +764,6 @@ video {
 }.bg-lime-200 {
   --tw-bg-opacity: 1;
   background-color: rgb(217 249 157 / var(--tw-bg-opacity));
-}.bg-amber-600 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(217 119 6 / var(--tw-bg-opacity));
 }.fill-current {
   fill: currentColor;
 }.p-4 {
@@ -830,6 +824,8 @@ video {
   padding-top: 1.5rem;
 }.pt-8 {
   padding-top: 2rem;
+}.pr-8 {
+  padding-right: 2rem;
 }.pl-1 {
   padding-left: 0.25rem;
 }.text-left {
@@ -851,6 +847,9 @@ video {
 }.text-xl {
   font-size: 1.25rem;
   line-height: 1.75rem;
+}.text-4xl {
+  font-size: 2.25rem;
+  line-height: 2.5rem;
 }.text-2xl {
   font-size: 1.5rem;
   line-height: 2rem;

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
     "/js/app.js": "/js/app.js?id=205efa21910945e3461ef278c977dbfe",
-    "/css/app.css": "/css/app.css?id=9536d848ed93c52db124d1f075b140dc"
+    "/css/app.css": "/css/app.css?id=10472721a7bb9430597228ef3e27c414"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
     "/js/app.js": "/js/app.js?id=205efa21910945e3461ef278c977dbfe",
-    "/css/app.css": "/css/app.css?id=354591bf5ba32eddacaca6e0f402fafe"
+    "/css/app.css": "/css/app.css?id=9536d848ed93c52db124d1f075b140dc"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
     "/js/app.js": "/js/app.js?id=205efa21910945e3461ef278c977dbfe",
-    "/css/app.css": "/css/app.css?id=6b4e473ad0d005da73cd36741f91cbf0"
+    "/css/app.css": "/css/app.css?id=6cbf03ef4410ca874ae53142f372bbf1"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
     "/js/app.js": "/js/app.js?id=205efa21910945e3461ef278c977dbfe",
-    "/css/app.css": "/css/app.css?id=10472721a7bb9430597228ef3e27c414"
+    "/css/app.css": "/css/app.css?id=6b4e473ad0d005da73cd36741f91cbf0"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
     "/js/app.js": "/js/app.js?id=205efa21910945e3461ef278c977dbfe",
-    "/css/app.css": "/css/app.css?id=6cbf03ef4410ca874ae53142f372bbf1"
+    "/css/app.css": "/css/app.css?id=5c78c3fc1e4a3fcc980731b189e4255d"
 }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,11 +1,5 @@
 <x-guest-layout>
     <x-auth-card>
-        <x-slot name="logo">
-            <a href="/">
-                <x-application-logo class="w-20 h-20 fill-current text-gray-500" />
-            </a>
-        </x-slot>
-
         <!-- Session Status -->
         <x-auth-session-status class="mb-4" :status="session('status')" />
 

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -11,14 +11,14 @@
 
             <!-- Email Address -->
             <div>
-                <x-label for="email" :value="__('Email')" />
+                <x-label for="email" :value="__('メールアドレス')" />
 
                 <x-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autofocus />
             </div>
 
             <!-- Password -->
             <div class="mt-4">
-                <x-label for="password" :value="__('Password')" />
+                <x-label for="password" :value="__('パスワード')" />
 
                 <x-input id="password" class="block mt-1 w-full"
                                 type="password"
@@ -30,19 +30,19 @@
             <div class="block mt-4">
                 <label for="remember_me" class="inline-flex items-center">
                     <input id="remember_me" type="checkbox" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" name="remember">
-                    <span class="ml-2 text-sm text-gray-600">{{ __('Remember me') }}</span>
+                    <span class="ml-2 text-sm text-gray-600">{{ __('記憶する') }}</span>
                 </label>
             </div>
 
             <div class="flex items-center justify-end mt-4">
                 @if (Route::has('password.request'))
                     <a class="underline text-sm text-gray-600 hover:text-gray-900" href="{{ route('password.request') }}">
-                        {{ __('Forgot your password?') }}
+                        {{ __('パスワードを忘れましたか？') }}
                     </a>
                 @endif
 
                 <x-button class="ml-3">
-                    {{ __('Log in') }}
+                    {{ __('ログイン') }}
                 </x-button>
             </div>
         </form>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,11 +1,5 @@
 <x-guest-layout>
     <x-auth-card>
-        <x-slot name="logo">
-            <a href="/">
-                <x-application-logo class="w-20 h-20 fill-current text-gray-500" />
-            </a>
-        </x-slot>
-
         <!-- Validation Errors -->
         <x-auth-validation-errors class="mb-4" :errors="$errors" />
 

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -6,13 +6,6 @@
         <form method="POST" action="{{ route('register') }}">
             @csrf
 
-            <!-- Name -->
-            <div>
-                <x-label for="name" :value="__('名前')" />
-
-                <x-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus />
-            </div>
-
             <!-- Email Address -->
             <div class="mt-4">
                 <x-label for="email" :value="__('メールアドレス')" />

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -8,21 +8,21 @@
 
             <!-- Name -->
             <div>
-                <x-label for="name" :value="__('Name')" />
+                <x-label for="name" :value="__('名前')" />
 
                 <x-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus />
             </div>
 
             <!-- Email Address -->
             <div class="mt-4">
-                <x-label for="email" :value="__('Email')" />
+                <x-label for="email" :value="__('メールアドレス')" />
 
                 <x-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required />
             </div>
 
             <!-- Password -->
             <div class="mt-4">
-                <x-label for="password" :value="__('Password')" />
+                <x-label for="password" :value="__('パスワード')" />
 
                 <x-input id="password" class="block mt-1 w-full"
                                 type="password"
@@ -32,7 +32,7 @@
 
             <!-- Confirm Password -->
             <div class="mt-4">
-                <x-label for="password_confirmation" :value="__('Confirm Password')" />
+                <x-label for="password_confirmation" :value="__('パスワード再入力')" />
 
                 <x-input id="password_confirmation" class="block mt-1 w-full"
                                 type="password"
@@ -41,11 +41,11 @@
 
             <div class="flex items-center justify-end mt-4">
                 <a class="underline text-sm text-gray-600 hover:text-gray-900" href="{{ route('login') }}">
-                    {{ __('Already registered?') }}
+                    {{ __('すでにユーザー登録されていますか？') }}
                 </a>
 
                 <x-button class="ml-4">
-                    {{ __('Register') }}
+                    {{ __('アカウント登録画面へ') }}
                 </x-button>
             </div>
         </form>

--- a/resources/views/components/auth-card.blade.php
+++ b/resources/views/components/auth-card.blade.php
@@ -1,8 +1,4 @@
 <div class="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-gray-100">
-    <div>
-        {{ $logo }}
-    </div>
-
     <div class="w-full sm:max-w-md mt-6 px-6 py-4 bg-white shadow-md overflow-hidden sm:rounded-lg">
         {{ $slot }}
     </div>

--- a/resources/views/components/element/button-a.blade.php
+++ b/resources/views/components/element/button-a.blade.php
@@ -15,10 +15,10 @@
 @endphp
 <a href="{{ $href }}" class="
     inline-flex justify-center
-    py-2 px-4
+    py-2 px-6
     border border-transparent
     shadow-sm
-    text-sm
+    text-lg
     font-medium
     rounded-md
     focus:outline-none focus:ring-2 focus:ring-offset-2 {{ getThemeClassForButtonA($theme) }}">

--- a/resources/views/components/register_account.blade.php
+++ b/resources/views/components/register_account.blade.php
@@ -1,48 +1,50 @@
-<p class="text-2xl mt-4">アカウント登録</p>
-<form action="{{ route('account.create') }}" method="post">
-    @method('POST')
-    @csrf
-    <div class="col-span-6 sm:col-span-4 py-2">
-        <label for="icon" class="block text-sm font-medium text-gray-700">アイコン</label>
-        <div class="w-12 h-12 border rounded-full border-gray-900 text-2xl flex justify-center items-center m-4">
-            +</div>
-    </div>
-    <div class="col-span-6 sm:col-span-4 py-2">
-        <label for="name" class="block text-sm font-medium text-gray-700">ニックネーム</label>
-        <input type="text" name="name" id="name" autocomplete="name"
-            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
-    </div>
-    <div class="col-span-6 sm:col-span-4 py-2">
-        <label for="birthday" class="block text-sm font-medium text-gray-700">誕生日</label>
-        <input type="date" name="birthday" id="birthday"
-            class="mt-1 block w- rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
-    </div>
-    <div class="flex items-start pt-1 pb-0">
-        <div class="flex h-5 items-center">
-            <input id="show_age_obscure" name="show_age_obscure" type="checkbox"
-                class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+<div class="w-1/3">
+    <p class="text-4xl mt-16 mb-8">アカウント登録</p>
+    <form action="{{ route('account.create') }}" method="post">
+        @method('POST')
+        @csrf
+        <div class="col-span-6 sm:col-span-4 py-2">
+            <label for="icon" class="block text-sm font-medium text-gray-700">アイコン</label>
+            <div class="w-12 h-12 border rounded-full border-gray-900 text-2xl flex justify-center items-center m-4">
+                +</div>
         </div>
-        <div class="flex-col ml-3 text-sm">
-            <label for="show_age_obscure" class="font-medium text-gray-700">年齢をあいまいに表示する</label>
+        <div class="col-span-6 sm:col-span-4 py-2">
+            <label for="name" class="block text-sm font-medium text-gray-700">ニックネーム</label>
+            <input type="text" name="name" id="name" autocomplete="name"
+                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
         </div>
-    </div>
-    <small class="font-light text-gray-700">※チェックすると「10 ~ 20歳」のように表示されます</small>
-
-    <div class="flex items-start pt-1 pb-0 mt-3">
-        <div class="flex h-5 items-center">
-            <input id="not_show_age" name="not_show_age" type="checkbox"
-                class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+        <div class="col-span-6 sm:col-span-4 py-2">
+            <label for="birthday" class="block text-sm font-medium text-gray-700">誕生日</label>
+            <input type="date" name="birthday" id="birthday"
+                class="mt-1 block w- rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
         </div>
-        <div class="flex-col ml-3 text-sm">
-            <label for="not_show_age" class="font-medium text-gray-700">年齢を表示しない</label>
+        <div class="flex items-start pt-1 pb-0">
+            <div class="flex h-5 items-center">
+                <input id="show_age_obscure" name="show_age_obscure" type="checkbox"
+                    class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+            </div>
+            <div class="flex-col ml-3 text-sm">
+                <label for="show_age_obscure" class="font-medium text-gray-700">年齢をあいまいに表示する</label>
+            </div>
         </div>
-    </div>
-
-    <div class="px-4 py-3 text-right sm:p-6">
-        <button type="submit"
-            class="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">登録</button>
-    </div>
-</form>
+        <small class="font-light text-gray-700">※チェックすると「10 ~ 20歳」のように表示されます</small>
+    
+        <div class="flex items-start pt-1 pb-0 mt-3">
+            <div class="flex h-5 items-center">
+                <input id="not_show_age" name="not_show_age" type="checkbox"
+                    class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+            </div>
+            <div class="flex-col ml-3 text-sm">
+                <label for="not_show_age" class="font-medium text-gray-700">年齢を表示しない</label>
+            </div>
+        </div>
+    
+        <div class="px-4 py-3 text-right sm:p-6">
+            <button type="submit"
+                class="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">登録</button>
+        </div>
+    </form>
+</div>
 
 <script>
     const show_age_obscure = document.getElementById('show_age_obscure');

--- a/resources/views/components/register_account.blade.php
+++ b/resources/views/components/register_account.blade.php
@@ -27,6 +27,17 @@
         </div>
     </div>
     <small class="font-light text-gray-700">※チェックすると「10 ~ 20歳」のように表示されます</small>
+
+    <div class="flex items-start pt-1 pb-0 mt-3">
+        <div class="flex h-5 items-center">
+            <input id="show_age_obscure" name="show_age_obscure" type="checkbox"
+                class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+        </div>
+        <div class="flex-col ml-3 text-sm">
+            <label for="show_age_obscure" class="font-medium text-gray-700">年齢を表示しない</label>
+        </div>
+    </div>
+
     <div class="px-4 py-3 text-right sm:p-6">
         <button type="submit"
             class="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">登録</button>

--- a/resources/views/components/register_account.blade.php
+++ b/resources/views/components/register_account.blade.php
@@ -1,4 +1,4 @@
-<p class="text-2xl">アカウント登録</p>
+<p class="text-2xl mt-4">アカウント登録</p>
 <form action="{{ route('account.create') }}" method="post">
     @method('POST')
     @csrf

--- a/resources/views/components/register_account.blade.php
+++ b/resources/views/components/register_account.blade.php
@@ -30,11 +30,11 @@
 
     <div class="flex items-start pt-1 pb-0 mt-3">
         <div class="flex h-5 items-center">
-            <input id="show_age_obscure" name="show_age_obscure" type="checkbox"
+            <input id="not_show_age" name="not_show_age" type="checkbox"
                 class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
         </div>
         <div class="flex-col ml-3 text-sm">
-            <label for="show_age_obscure" class="font-medium text-gray-700">年齢を表示しない</label>
+            <label for="not_show_age" class="font-medium text-gray-700">年齢を表示しない</label>
         </div>
     </div>
 
@@ -43,3 +43,16 @@
             class="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">登録</button>
     </div>
 </form>
+
+<script>
+    const show_age_obscure = document.getElementById('show_age_obscure');
+    const not_show_age     = document.getElementById('not_show_age');
+
+    show_age_obscure.addEventListener('click', () => {
+        if (show_age_obscure.checked) not_show_age.checked = false;
+    });
+
+    not_show_age.addEventListener('click', () => {
+        if (not_show_age.checked) show_age_obscure.checked = false;
+    });
+</script>

--- a/resources/views/components/register_account.blade.php
+++ b/resources/views/components/register_account.blade.php
@@ -27,7 +27,7 @@
         </div>
     </div>
     <small class="font-light text-gray-700">※チェックすると「10 ~ 20歳」のように表示されます</small>
-    <div class="bg-gray-50 px-4 py-3 text-right sm:p-6">
+    <div class="px-4 py-3 text-right sm:p-6">
         <button type="submit"
             class="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">登録</button>
     </div>

--- a/resources/views/tweet/index.blade.php
+++ b/resources/views/tweet/index.blade.php
@@ -24,7 +24,7 @@
         @endauth
         <div class="flex justify-center">
           <!-- ここにアイコン(imgタグ)を設置する予定！ -->
-          <h1 class="text-green-500 text-4xl font-bold mt-8 mb-8">SpaChat</h1> <!-- textの色 before text-blue-500 候補1 text-pink-300 候補2 bg-lime-200 -->
+          <h1 class="text-green-500 text-6xl font-bold mt-8 mb-8">SpaChat</h1> <!-- textの色 before text-blue-500 候補1 text-pink-300 候補2 bg-lime-200 -->
         </div>
         @auth
           <div class="p-4">
@@ -72,6 +72,9 @@
               <x-element.button-a :href="route('register')" theme="secondary">会員登録</x-element.button-a>
             </div>
           </div>
+
+          <!-- ここにh1タグで「SpaChatへようこそ！」てやるべきか -->
+          <h3 class="text-justify my-12 text-2xl border-solid border-2 p-8 border-amber-600 bg-amber-600">SpaChat（スパチャット）は、「温泉のようなチャット場」を由来として誕生したSNSです。<br><br>温泉は入ると疲れた体を回復してくれるだけでなく、癒されたり、最近ではメンタルが回復する効果も期待されていると言われています。そして、温泉はみんなが入ることが出来ます。<br><br>SpaChatも温泉と同じように、「SNSが原因で精神的に病んでしまった人が幸せになることが出来るSNSであってほしい」という願いから誕生しました。<br><br>SpaChatは他のSNSとは違い、他のアカウントのいいねの数やフォロワーの数などが表示されない仕組みになっています。他のSNSにはないオリジナルな機能を備えているSpaChat、是非楽しんでください！</h3>
         @endguest
       </div>
     </div>

--- a/resources/views/tweet/index.blade.php
+++ b/resources/views/tweet/index.blade.php
@@ -8,7 +8,7 @@
     <link href="{{ mix('/css/app.css') }}" rel="stylesheet">
     <title>original-sns</title>
 </head>
-<body class="bg-gray-50">
+<body class="bg-green-200"> <!-- bodyの色 before bg-gray-50 候補1 bg-pink-100 候補2 bg-lime-200 -->
     <div class="flex justify-center">
       <div class="max-w-screen-sm w-full">
         @auth
@@ -22,7 +22,10 @@
             </div>
           </form>
         @endauth
-        <h2 class="text-center text-blue-500 text-4xl font-bold mt-8 mb-8">original-sns</h2>
+        <div class="flex justify-center">
+          <!-- ここにアイコン(imgタグ)を設置する予定！ -->
+          <h1 class="text-green-500 text-4xl font-bold mt-8 mb-8">SpaChat</h1> <!-- textの色 before text-blue-500 候補1 text-pink-300 候補2 bg-lime-200 -->
+        </div>
         @auth
           <div class="p-4">
               @if(session('feedback.success'))

--- a/resources/views/tweet/index.blade.php
+++ b/resources/views/tweet/index.blade.php
@@ -7,10 +7,10 @@
         content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <link href="{{ mix('/css/app.css') }}" rel="stylesheet">
-    <title>original-sns</title>
+    <title>SpaChat</title>
 </head>
 
-<body class="bg-gray-50">
+<body class="bg-green-200"> <!-- bodyの色 before bg-gray-50 候補1 bg-pink-100 候補2 bg-lime-200 -->
     <div class="flex justify-center">
         <div class="max-w-screen-sm w-full">
             @auth
@@ -24,7 +24,12 @@
                     </div>
                 </form>
             @endauth
-            <h2 class="text-center text-blue-500 text-4xl font-bold mt-8 mb-8">original-sns</h2>
+
+            <div class="flex justify-center">
+              <!-- ここにアイコン(imgタグ)を設置する予定！ -->
+              <h1 class="text-green-500 text-6xl font-bold mt-8 mb-8">SpaChat</h1> <!-- textの色 before text-blue-500 候補1 text-pink-300 候補2 bg-lime-200 -->
+            </div>
+
             @auth
                 @if ($account === null)
                     <x-register_account></x-register_account>

--- a/resources/views/tweet/index.blade.php
+++ b/resources/views/tweet/index.blade.php
@@ -77,6 +77,7 @@
                     <x-tweet.list :tweets="$tweets" :goods="$goods" :isGoods="$isGoods"></x-tweet.list>
                 @endif
             @endauth
+
             @guest
                 <div class="flex flex-wrap justify-center">
                     <div class="w-1/2 p-4 flex flex-wrap justify-evenly">
@@ -84,6 +85,9 @@
                         <x-element.button-a :href="route('register')" theme="secondary">会員登録</x-element.button-a>
                     </div>
                 </div>
+
+                <!-- ここにh1タグで「SpaChatへようこそ！」てやるべきか -->
+                <h3 class="text-justify my-12 text-2xl border-solid border-2 p-8 border-amber-600 bg-amber-600">SpaChat（スパチャット）は、「温泉のようなチャット場」を由来として誕生したSNSです。<br><br>温泉は入ると疲れた体を回復してくれるだけでなく、癒されたり、最近ではメンタルが回復する効果も期待されていると言われています。そして、温泉はみんなが入ることが出来ます。<br><br>SpaChatも温泉と同じように、「SNSが原因で精神的に病んでしまった人が幸せになることが出来るSNSであってほしい」という願いから誕生しました。<br><br>SpaChatは他のSNSとは違い、他のアカウントのいいねの数やフォロワーの数などが表示されない仕組みになっています。他のSNSにはないオリジナルな機能を備えているSpaChat、是非楽しんでください！</h3>
             @endguest
         </div>
     </div>

--- a/resources/views/tweet/index.blade.php
+++ b/resources/views/tweet/index.blade.php
@@ -11,30 +11,58 @@
 </head>
 
 <body class="bg-green-200"> <!-- bodyの色 before bg-gray-50 候補1 bg-pink-100 候補2 bg-lime-200 -->
-    <div class="flex justify-center">
-        <div class="max-w-screen-sm w-full">
-            @auth
-                <form action="{{ route('logout') }}" method="post">
-                    @csrf
-                    <div class="flex justify-end p-4">
-                        <button class="mt-2 text-sm text-gray-500 hover:text-gray-800"
-                            onclick="event.preventDefault(); this.closest('form').submit();">
-                            ログアウト
-                        </button>
-                    </div>
-                </form>
-            @endauth
+    @guest
+        <div class="flex justify-center">
+          <!-- ここにアイコン(imgタグ)を設置する予定！ -->
+          <h1 class="text-green-500 text-6xl font-bold mt-8 mb-8">SpaChat</h1> <!-- textの色 before text-blue-500 候補1 text-pink-300 候補2 bg-lime-200 -->
+        </div>
 
-            <div class="flex justify-center">
-              <!-- ここにアイコン(imgタグ)を設置する予定！ -->
-              <h1 class="text-green-500 text-6xl font-bold mt-8 mb-8">SpaChat</h1> <!-- textの色 before text-blue-500 候補1 text-pink-300 候補2 bg-lime-200 -->
+        <div class="flex flex-wrap justify-center">
+          <div class="w-1/2 p-4 flex flex-wrap justify-evenly">
+              <x-element.button-a :href="route('login')">ログイン</x-element.button-a>
+              <x-element.button-a :href="route('register')" theme="secondary">会員登録</x-element.button-a>
+          </div>
+        </div>
+    
+        <!-- ここにh1タグで「SpaChatへようこそ！」てやるべきか -->
+        <h3 class="text-justify my-12 text-2xl p-8">SpaChat（スパチャット）は、「温泉のようなチャット場」を由来として誕生したSNSです。<br><br>温泉は入ると疲れた体を回復してくれるだけでなく、癒されたり、最近ではメンタルが回復する効果も期待されていると言われています。そして、温泉はみんなが入ることが出来ます。<br><br>SpaChatも温泉と同じように、「SNSが原因で精神的に病んでしまった人が幸せになることが出来るSNSであってほしい」という願いから誕生しました。<br><br>SpaChatは他のSNSとは違い、他のアカウントのいいねの数やフォロワーの数などが表示されない仕組みになっています。他のSNSにはないオリジナルな機能を備えているSpaChat、是非楽しんでください！</h3>
+    @endguest
+
+    @auth
+        @if ($account === null)
+            <div class="flex">
+              <div class="w-1/3"><!--余白用--></div>
+              <x-register_account></x-register_account>
+              <form action="{{ route('logout') }}" method="post">
+                  @csrf
+                  <div>
+                      <button class="ml-2 mt-6 text-sm text-gray-500 hover:text-gray-800"
+                          onclick="event.preventDefault(); this.closest('form').submit();">
+                          最初からやり直す
+                      </button>
+                  </div>
+              </form>
             </div>
+        @endif
+    @endauth
 
+    <div class="flex">
+        @if ($account)
+            @if ($account->id === Auth::id())
+                <div class="flex justify-end pt-6 pr-8 w-1/3">
+                  <ul class="text-4xl">
+                    <li class="mb-12"><a href="{{ route('tweet.index') }}">タイムライン</a></li>
+                    <li class="mb-12"><a href="">通知</a></li>
+                    <li class="mb-12"><a href="">メッセージ</a></li>
+                    <li class="mb-12"><a href="">プロフィール</a></li>
+                    <li class="mb-12"><a href="">設定</a></li>
+                  </ul>
+                </div>
+            @endif
+        @endif
+
+        <div class="w-1/3">
             @auth
-                @if ($account === null)
-                    <x-register_account></x-register_account>
-                @endif
-
                 @if ($account !== null)
                     <div class="p-4">
                         @if (session('feedback.success'))
@@ -42,7 +70,7 @@
                         @endif
                         <form action="{{ route('tweet.create') }}" method="post">
                             @csrf
-                            <div class="mt-1">
+                            <div class="mt-2">
                                 <textarea name="tweet" rows="3"
                                     class="focus:ring-blue-400 focus:border-blue-400 mt-1 block 
                               w-full sm:text-sm border border-gray-300 rounded-md p-2"
@@ -77,19 +105,21 @@
                     <x-tweet.list :tweets="$tweets" :goods="$goods" :isGoods="$isGoods"></x-tweet.list>
                 @endif
             @endauth
-
-            @guest
-                <div class="flex flex-wrap justify-center">
-                    <div class="w-1/2 p-4 flex flex-wrap justify-evenly">
-                        <x-element.button-a :href="route('login')">ログイン</x-element.button-a>
-                        <x-element.button-a :href="route('register')" theme="secondary">会員登録</x-element.button-a>
-                    </div>
-                </div>
-
-                <!-- ここにh1タグで「SpaChatへようこそ！」てやるべきか -->
-                <h3 class="text-justify my-12 text-2xl border-solid border-2 p-8 border-amber-600 bg-amber-600">SpaChat（スパチャット）は、「温泉のようなチャット場」を由来として誕生したSNSです。<br><br>温泉は入ると疲れた体を回復してくれるだけでなく、癒されたり、最近ではメンタルが回復する効果も期待されていると言われています。そして、温泉はみんなが入ることが出来ます。<br><br>SpaChatも温泉と同じように、「SNSが原因で精神的に病んでしまった人が幸せになることが出来るSNSであってほしい」という願いから誕生しました。<br><br>SpaChatは他のSNSとは違い、他のアカウントのいいねの数やフォロワーの数などが表示されない仕組みになっています。他のSNSにはないオリジナルな機能を備えているSpaChat、是非楽しんでください！</h3>
-            @endguest
         </div>
+
+        @auth
+            @if (($account) && ($account->id === Auth::id()))
+                <form action="{{ route('logout') }}" method="post">
+                    @csrf
+                    <div>
+                        <button class="ml-2 mt-6 text-sm text-gray-500 hover:text-gray-800"
+                            onclick="event.preventDefault(); this.closest('form').submit();">
+                            ログアウト
+                        </button>
+                    </div>
+                </form>
+            @endif
+        @endauth
     </div>
     <script src="{{ mix('/js/app.js') }}"></script>
 </body>


### PR DESCRIPTION
## 詳細

* アカウント作成時に、show_age_obscureカラムが登録できないエラーが発生していたため、そのエラーを修正。（0の値が年齢非表示、1が曖昧に表示、2がハッキリと表示とする。）

* tweet画面のタイムライン表示数を50件までに設定。（ある程度制限をつけとかないとサイトの大きさが膨大になってしまうのではないかと考えたため。）50件はあくまでも仮の数字。

* tweet画面の左側に、Twitterみたいにプロフィールやタイムライン、メッセージなどを選択できるようなリストを追加。

* タイムライン表示時は「ログアウト」、アカウント作成時は「最初からやり直す」という表記に設定。

## 把握してほしいこと

* デフォルトであるregister画面とlogin画面をいじっているが、たいせいがチケット取ってくれているのを忘れていただけなので、無視してOK。

* tweet画面に限った話ではないが、まだレスポンシブ対応は全く出来ていないため、後々レスポンシブ対応を行う必要がある。

* リスト表示の部分が位置固定をすることが出来ていないため、後々位置固定をした方がいいかも？

* デザイン構造に関しては、未だに全く考えることが出来ていないため、もしたいせいが良いデザイン構造思い付いたらどんどん言ってほしい！